### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cosmos/stack-team
+** @cosmos/stack-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cosmos/stack-team


### PR DESCRIPTION
Adds `.github/CODEOWNERS` to assign `@cosmos/stack-team` as code owners for all files.